### PR TITLE
Expr recursion

### DIFF
--- a/lib/frames/frame-arg.d.ts
+++ b/lib/frames/frame-arg.d.ts
@@ -9,5 +9,5 @@ export declare class FrameArg extends FrameSymbol {
     };
     protected static _for(symbol: string): FrameArg;
     protected constructor(data: string);
-    in(context: Frame): Frame;
+    in(contexts?: Frame[]): Frame;
 }

--- a/lib/frames/frame-arg.js
+++ b/lib/frames/frame-arg.js
@@ -4,6 +4,7 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
+var frame_1 = require("./frame");
 var frame_symbol_1 = require("./frame-symbol");
 var FrameArg = (function (_super) {
     __extends(FrameArg, _super);
@@ -22,10 +23,11 @@ var FrameArg = (function (_super) {
         var exists = FrameArg.args[symbol];
         return exists || (FrameArg.args[symbol] = new FrameArg(symbol));
     };
-    FrameArg.prototype.in = function (context) {
+    FrameArg.prototype.in = function (contexts) {
+        if (contexts === void 0) { contexts = [frame_1.Frame.nil]; }
         var level = this.data.length;
         if (level <= 1) {
-            return context;
+            return contexts[0];
         }
         else {
             return FrameArg.level(level - 1);

--- a/lib/frames/frame-array.d.ts
+++ b/lib/frames/frame-array.d.ts
@@ -7,6 +7,6 @@ export declare class FrameArray extends FrameList {
     });
     string_open(): string;
     string_close(): string;
-    in(context?: Frame): Frame;
+    in(contexts?: Frame[]): Frame;
     at(index: number): Frame;
 }

--- a/lib/frames/frame-array.js
+++ b/lib/frames/frame-array.js
@@ -15,9 +15,10 @@ var FrameArray = (function (_super) {
     ;
     FrameArray.prototype.string_close = function () { return FrameArray.END_ARRAY; };
     ;
-    FrameArray.prototype.in = function (context) {
-        if (context === void 0) { context = frame_1.Frame.nil; }
-        return new FrameArray(this.data.map(function (f) { return f.in(context); }));
+    FrameArray.prototype.in = function (contexts) {
+        if (contexts === void 0) { contexts = [frame_1.Frame.nil]; }
+        contexts.push(this);
+        return new FrameArray(this.data.map(function (f) { return f.in(contexts); }));
     };
     FrameArray.prototype.at = function (index) {
         return this.data[index];

--- a/lib/frames/frame-expr.d.ts
+++ b/lib/frames/frame-expr.d.ts
@@ -4,7 +4,7 @@ export declare class FrameExpr extends FrameList {
     constructor(data: Array<Frame>, meta?: {
         [key: string]: Frame;
     });
-    in(context?: Frame): Frame;
+    in(contexts?: Frame[]): Frame;
     call(context: Frame): Frame;
     toStringDataArray(): string[];
 }

--- a/lib/frames/frame-expr.js
+++ b/lib/frames/frame-expr.js
@@ -19,19 +19,19 @@ var FrameExpr = (function (_super) {
             new frame_name_1.FrameName(key),
         ]);
     };
-    FrameExpr.prototype.in = function (context) {
+    FrameExpr.prototype.in = function (contexts) {
         var _this = this;
-        if (context === void 0) { context = frame_1.Frame.nil; }
+        if (contexts === void 0) { contexts = [frame_1.Frame.nil]; }
         return this.data.reduce(function (sum, item) {
-            var value = item.in(context);
+            var value = item.in(contexts);
             if (value === frame_1.Frame.missing) {
-                value = item.in(_this);
+                value = item.in([_this]);
             }
             return sum.call(value);
         }, frame_1.Frame.nil);
     };
     FrameExpr.prototype.call = function (context) {
-        return this.in(context);
+        return this.in([context]);
     };
     ;
     FrameExpr.prototype.toStringDataArray = function () {

--- a/lib/frames/frame-expr.js
+++ b/lib/frames/frame-expr.js
@@ -20,13 +20,10 @@ var FrameExpr = (function (_super) {
         ]);
     };
     FrameExpr.prototype.in = function (contexts) {
-        var _this = this;
         if (contexts === void 0) { contexts = [frame_1.Frame.nil]; }
+        contexts.push(this);
         return this.data.reduce(function (sum, item) {
             var value = item.in(contexts);
-            if (value === frame_1.Frame.missing) {
-                value = item.in([_this]);
-            }
             return sum.call(value);
         }, frame_1.Frame.nil);
     };

--- a/lib/frames/frame-lazy.d.ts
+++ b/lib/frames/frame-lazy.d.ts
@@ -6,7 +6,7 @@ export declare class FrameLazy extends FrameExpr {
     constructor(data: Array<Frame>, meta?: Context);
     string_open(): string;
     string_close(): string;
-    in(context: Frame): Frame;
+    in(contexts?: Frame[]): Frame;
     call(argument: Frame): FrameExpr;
     protected meta_for(context: Frame): {
         [key: string]: Frame;

--- a/lib/frames/frame-lazy.js
+++ b/lib/frames/frame-lazy.js
@@ -16,11 +16,12 @@ var FrameLazy = (function (_super) {
     ;
     FrameLazy.prototype.string_close = function () { return " " + FrameLazy.LAZY_END; };
     ;
-    FrameLazy.prototype.in = function (context) {
+    FrameLazy.prototype.in = function (contexts) {
+        if (contexts === void 0) { contexts = [frame_1.Frame.nil]; }
         if (this.data.length === 0) {
             return this;
         }
-        return new frame_expr_1.FrameExpr(this.data, this.meta_for(context));
+        return new frame_expr_1.FrameExpr(this.data, this.meta_for(contexts[0]));
     };
     FrameLazy.prototype.call = function (argument) {
         return new frame_expr_1.FrameExpr(argument.asArray(), this.meta_for(argument));

--- a/lib/frames/frame-name.d.ts
+++ b/lib/frames/frame-name.d.ts
@@ -6,7 +6,7 @@ export declare class FrameName extends FrameAtom {
     constructor(symbol: string, meta?: {
         [key: string]: Frame;
     });
-    in(context?: Frame): FrameSymbol;
+    in(contexts?: Frame[]): FrameSymbol;
     string_prefix(): string;
     protected toData(): FrameSymbol;
 }

--- a/lib/frames/frame-name.js
+++ b/lib/frames/frame-name.js
@@ -13,8 +13,8 @@ var FrameName = (function (_super) {
         _super.call(this, meta);
         this.data = frame_symbol_1.FrameSymbol.for(symbol);
     }
-    FrameName.prototype.in = function (context) {
-        if (context === void 0) { context = frame_1.Frame.nil; }
+    FrameName.prototype.in = function (contexts) {
+        if (contexts === void 0) { contexts = [frame_1.Frame.nil]; }
         return this.data;
     };
     FrameName.prototype.string_prefix = function () { return FrameName.NAME_BEGIN; };

--- a/lib/frames/frame-symbol.d.ts
+++ b/lib/frames/frame-symbol.d.ts
@@ -8,7 +8,7 @@ export declare class FrameSymbol extends FrameAtom {
     constructor(data: string, meta?: {
         [key: string]: Frame;
     });
-    in(context?: Frame): Frame;
+    in(contexts?: Frame[]): Frame;
     called_by(context: Frame): Frame;
     protected toData(): string;
 }

--- a/lib/frames/frame-symbol.js
+++ b/lib/frames/frame-symbol.js
@@ -16,12 +16,12 @@ var FrameSymbol = (function (_super) {
         var exists = FrameSymbol.symbols[symbol];
         return exists || (FrameSymbol.symbols[symbol] = new FrameSymbol(symbol));
     };
-    FrameSymbol.prototype.in = function (context) {
-        if (context === void 0) { context = frame_1.Frame.nil; }
-        return context.get(this.data);
+    FrameSymbol.prototype.in = function (contexts) {
+        if (contexts === void 0) { contexts = [frame_1.Frame.nil]; }
+        return contexts[0].get(this.data);
     };
     FrameSymbol.prototype.called_by = function (context) {
-        return this.in(context);
+        return this.in([context]);
     };
     FrameSymbol.prototype.toData = function () { return this.data; };
     FrameSymbol.symbols = {};

--- a/lib/frames/frame-symbol.js
+++ b/lib/frames/frame-symbol.js
@@ -18,7 +18,14 @@ var FrameSymbol = (function (_super) {
     };
     FrameSymbol.prototype.in = function (contexts) {
         if (contexts === void 0) { contexts = [frame_1.Frame.nil]; }
-        return contexts[0].get(this.data);
+        for (var _i = 0, contexts_1 = contexts; _i < contexts_1.length; _i++) {
+            var context_1 = contexts_1[_i];
+            var value = context_1.get(this.data);
+            if (value !== frame_1.Frame.missing) {
+                return value;
+            }
+        }
+        return frame_1.Frame.missing;
     };
     FrameSymbol.prototype.called_by = function (context) {
         return this.in([context]);

--- a/lib/frames/frame.d.ts
+++ b/lib/frames/frame.d.ts
@@ -22,7 +22,7 @@ export declare class Frame {
     get(key: string, origin?: this): Frame;
     set(key: string, value: Frame): Frame;
     at(index: number): Frame;
-    in(context?: Frame): Frame;
+    in(contexts?: Frame[]): Frame;
     apply(argument: Frame): Frame;
     called_by(context: Frame): Frame;
     call(argument: Frame): Frame;

--- a/lib/frames/frame.js
+++ b/lib/frames/frame.js
@@ -47,8 +47,8 @@ var Frame = (function () {
     Frame.prototype.at = function (index) {
         return Frame.nil;
     };
-    Frame.prototype.in = function (context) {
-        if (context === void 0) { context = Frame.nil; }
+    Frame.prototype.in = function (contexts) {
+        if (contexts === void 0) { contexts = [Frame.nil]; }
         return this;
     };
     Frame.prototype.apply = function (argument) {

--- a/lib/maml.js
+++ b/lib/maml.js
@@ -5,7 +5,6 @@ var HTML_PREFIX = "<!DOCTYPE html>";
 var body = function (level) {
     if (level === void 0) { level = 1; }
     return new frames_1.FrameExpr([
-        new frames_1.FrameString(HTML_PREFIX),
         new frames_1.FrameExpr([
             new frames_1.FrameSymbol("tag"),
             new frames_1.FrameString("body"),

--- a/lib/maml.js
+++ b/lib/maml.js
@@ -1,12 +1,16 @@
 "use strict";
 var frames_1 = require("./frames");
 var tag_1 = require("./maml/tag");
+var HTML_PREFIX = "<!DOCTYPE html>";
 var body = function (level) {
     if (level === void 0) { level = 1; }
     return new frames_1.FrameExpr([
-        new frames_1.FrameSymbol("tag"),
-        new frames_1.FrameString("body"),
-        frames_1.FrameArg.here(),
+        new frames_1.FrameString(HTML_PREFIX),
+        new frames_1.FrameExpr([
+            new frames_1.FrameSymbol("tag"),
+            new frames_1.FrameString("body"),
+            frames_1.FrameArg.here(),
+        ]),
     ], { tag: tag_1.tag });
 };
 exports.maml = body();

--- a/lib/maml.js
+++ b/lib/maml.js
@@ -5,6 +5,7 @@ var HTML_PREFIX = "<!DOCTYPE html>";
 var body = function (level) {
     if (level === void 0) { level = 1; }
     return new frames_1.FrameExpr([
+        new frames_1.FrameString(HTML_PREFIX),
         new frames_1.FrameExpr([
             new frames_1.FrameSymbol("tag"),
             new frames_1.FrameString("body"),

--- a/lib/maml.js
+++ b/lib/maml.js
@@ -1,9 +1,12 @@
 "use strict";
 var frames_1 = require("./frames");
 var tag_1 = require("./maml/tag");
-var body = new frames_1.FrameString("body");
-exports.maml = new frames_1.FrameExpr([
-    new frames_1.FrameSymbol("tag"),
-    body,
-    frames_1.FrameArg.here(),
-], { tag: tag_1.tag });
+var body = function (level) {
+    if (level === void 0) { level = 1; }
+    return new frames_1.FrameExpr([
+        new frames_1.FrameSymbol("tag"),
+        new frames_1.FrameString("body"),
+        frames_1.FrameArg.here(),
+    ], { tag: tag_1.tag });
+};
+exports.maml = body();

--- a/lib/maml.js
+++ b/lib/maml.js
@@ -3,9 +3,7 @@ var frames_1 = require("./frames");
 var tag_1 = require("./maml/tag");
 var body = new frames_1.FrameString("body");
 exports.maml = new frames_1.FrameExpr([
-    new frames_1.FrameExpr([
-        new frames_1.FrameSymbol("tag"),
-        body,
-        frames_1.FrameArg.here(),
-    ]),
+    new frames_1.FrameSymbol("tag"),
+    body,
+    frames_1.FrameArg.here(),
 ], { tag: tag_1.tag });

--- a/src/frames/frame-arg.ts
+++ b/src/frames/frame-arg.ts
@@ -24,10 +24,10 @@ export class FrameArg extends FrameSymbol {
     super(data);
   }
 
-  public in(context: Frame): Frame {
+  public in(contexts = [Frame.nil]): Frame {
     const level = this.data.length;
     if (level <= 1) {
-      return context;
+      return contexts[0];
     } else {
       return FrameArg.level(level - 1);
     }

--- a/src/frames/frame-array.ts
+++ b/src/frames/frame-array.ts
@@ -11,8 +11,9 @@ export class FrameArray extends FrameList {
   public string_open() { return FrameArray.BEGIN_ARRAY; };
   public string_close() { return FrameArray.END_ARRAY; };
 
-  public in(context = Frame.nil): Frame {
-    return new FrameArray(this.data.map((f) => { return f.in(context); }));
+  public in(contexts = [Frame.nil]): Frame {
+    contexts.push(this);
+    return new FrameArray(this.data.map((f) => { return f.in(contexts); }));
   }
 
   public at(index: number) {

--- a/src/frames/frame-expr.ts
+++ b/src/frames/frame-expr.ts
@@ -14,18 +14,18 @@ export class FrameExpr extends FrameList {
     super(data, meta);
   }
 
-  public in(context = Frame.nil) {
+  public in(contexts = [Frame.nil]) {
     return this.data.reduce((sum: Frame, item: Frame) => {
-      let value = item.in(context);
+      let value = item.in(contexts);
       if (value === Frame.missing) {
-        value = item.in(this);
+        value = item.in([this]);
       }
       return sum.call(value);
     }, Frame.nil);
   }
 
   public call(context: Frame) {
-    return this.in(context);
+    return this.in([context]);
   };
 
   public toStringDataArray(): string[] {

--- a/src/frames/frame-expr.ts
+++ b/src/frames/frame-expr.ts
@@ -15,11 +15,9 @@ export class FrameExpr extends FrameList {
   }
 
   public in(contexts = [Frame.nil]) {
+    contexts.push(this);
     return this.data.reduce((sum: Frame, item: Frame) => {
       let value = item.in(contexts);
-      if (value === Frame.missing) {
-        value = item.in([this]);
-      }
       return sum.call(value);
     }, Frame.nil);
   }

--- a/src/frames/frame-lazy.ts
+++ b/src/frames/frame-lazy.ts
@@ -12,11 +12,11 @@ export class FrameLazy extends FrameExpr {
   public string_open() { return FrameLazy.LAZY_BEGIN + " "; };
   public string_close() { return  " " + FrameLazy.LAZY_END; };
 
-  public in(context: Frame): Frame {
+  public in(contexts = [Frame.nil]): Frame {
     if (this.data.length === 0) {
       return this;
     }
-    return new FrameExpr(this.data, this.meta_for(context));
+    return new FrameExpr(this.data, this.meta_for(contexts[0]));
   }
 
   public call(argument: Frame): FrameExpr {

--- a/src/frames/frame-name.ts
+++ b/src/frames/frame-name.ts
@@ -11,7 +11,7 @@ export class FrameName extends FrameAtom {
     this.data = FrameSymbol.for(symbol);
   }
 
-  public in(context = Frame.nil) {
+  public in(contexts = [Frame.nil]) {
     return this.data;
   }
 

--- a/src/frames/frame-symbol.ts
+++ b/src/frames/frame-symbol.ts
@@ -13,7 +13,13 @@ export class FrameSymbol extends FrameAtom {
   }
 
   public in(contexts = [Frame.nil]) {
-    return contexts[0].get(this.data);
+    for (let context of contexts) {
+      let value = context.get(this.data);
+      if (value !== Frame.missing) {
+        return value;
+      }
+    }
+    return Frame.missing;
   }
 
   public called_by(context: Frame) {

--- a/src/frames/frame-symbol.ts
+++ b/src/frames/frame-symbol.ts
@@ -12,12 +12,12 @@ export class FrameSymbol extends FrameAtom {
     super(meta);
   }
 
-  public in(context = Frame.nil) {
-    return context.get(this.data);
+  public in(contexts = [Frame.nil]) {
+    return contexts[0].get(this.data);
   }
 
   public called_by(context: Frame) {
-    return this.in(context);
+    return this.in([context]);
   }
 
   protected toData() { return this.data; }

--- a/src/frames/frame.ts
+++ b/src/frames/frame.ts
@@ -45,7 +45,7 @@ export class Frame {
     return Frame.nil;
   }
 
-  public in(context = Frame.nil): Frame {
+  public in(contexts = [Frame.nil]): Frame {
     return this;
   }
 

--- a/src/maml.ts
+++ b/src/maml.ts
@@ -5,6 +5,7 @@ const HTML_PREFIX = "<!DOCTYPE html>";
 
 const body = (level = 1) => {
   return new FrameExpr([
+    new FrameString(HTML_PREFIX),
     new FrameExpr([
       new FrameSymbol("tag"),
       new FrameString("body"),

--- a/src/maml.ts
+++ b/src/maml.ts
@@ -4,9 +4,7 @@ import { tag } from "./maml/tag";
 const body = new FrameString("body");
 
 export const maml = new FrameExpr([
-  new FrameExpr([
-    new FrameSymbol("tag"),
-    body,
-    FrameArg.here(),
-  ]),
+  new FrameSymbol("tag"),
+  body,
+  FrameArg.here(),
 ], {tag});

--- a/src/maml.ts
+++ b/src/maml.ts
@@ -1,10 +1,12 @@
 import { FrameArg, FrameExpr, FrameString, FrameSymbol } from "./frames";
 import { tag } from "./maml/tag";
 
-const body = new FrameString("body");
+const body = (level = 1) => {
+  return new FrameExpr([
+    new FrameSymbol("tag"),
+    new FrameString("body"),
+    FrameArg.here(),
+  ], {tag});
+};
 
-export const maml = new FrameExpr([
-  new FrameSymbol("tag"),
-  body,
-  FrameArg.here(),
-], {tag});
+export const maml = body();

--- a/src/maml.ts
+++ b/src/maml.ts
@@ -1,11 +1,10 @@
 import { FrameArg, FrameExpr, FrameString, FrameSymbol } from "./frames";
 import { tag } from "./maml/tag";
 
-const HTML_PREFIX = "<!DOCTYPE html>"
+const HTML_PREFIX = "<!DOCTYPE html>";
 
 const body = (level = 1) => {
   return new FrameExpr([
-    new FrameString(HTML_PREFIX),
     new FrameExpr([
       new FrameSymbol("tag"),
       new FrameString("body"),

--- a/src/maml.ts
+++ b/src/maml.ts
@@ -1,11 +1,16 @@
 import { FrameArg, FrameExpr, FrameString, FrameSymbol } from "./frames";
 import { tag } from "./maml/tag";
 
+const HTML_PREFIX = "<!DOCTYPE html>"
+
 const body = (level = 1) => {
   return new FrameExpr([
-    new FrameSymbol("tag"),
-    new FrameString("body"),
-    FrameArg.here(),
+    new FrameString(HTML_PREFIX),
+    new FrameExpr([
+      new FrameSymbol("tag"),
+      new FrameString("body"),
+      FrameArg.here(),
+    ]),
   ], {tag});
 };
 

--- a/test/frames/frame-arg-spec.ts
+++ b/test/frames/frame-arg-spec.ts
@@ -15,7 +15,7 @@ describe("FrameArg", () => {
 
     it ("evaluates to the context", () => {
       const context = new FrameString("context", {atom: frame_arg});
-      expect(FrameArg.here().in(context)).to.equal(context);
+      expect(FrameArg.here().in([context])).to.equal(context);
     });
   });
 
@@ -34,8 +34,8 @@ describe("FrameArg", () => {
       const context = new FrameString("context", {atom: frame_arg});
       const level_3 = FrameArg.level(3);
       const level_2 = FrameArg.level(2);
-      expect(level_3.in(context)).to.equal(level_2);
-      expect(level_2.in(context)).to.equal(frame_arg);
+      expect(level_3.in([context])).to.equal(level_2);
+      expect(level_2.in([context])).to.equal(frame_arg);
     });
   });
 });

--- a/test/frames/frame-expr-spec.ts
+++ b/test/frames/frame-expr-spec.ts
@@ -6,13 +6,14 @@ describe("FrameExpr", () => {
   const js_string = "Hello";
   const context = new FrameString("context");
   const frame_string = new FrameString(js_string);
-  const frame_expr = new FrameExpr([frame, frame_string], {context: context});
 
   it("stringifies with parentheses", () => {
+    const frame_expr = new FrameExpr([frame, frame_string], {context: context});
     expect(frame_expr.toString()).to.equal(`(() “${js_string}”, .context “context”;)`);
   });
 
   it("replaces nil when evaluated", () => {
+    const frame_expr = new FrameExpr([frame, frame_string], {context: context});
     const result = frame_expr.in(frame);
     expect(result).to.equal(frame_string);
   });
@@ -20,8 +21,8 @@ describe("FrameExpr", () => {
   it("concatenates string expressions when called", () => {
     const js_string_2 = ", MAML!";
     const frame_string_2 = new FrameString(js_string_2);
-    const frame_expr_2 = new FrameExpr([frame_string, frame_string_2]);
-    const result = frame_expr_2.in(frame);
+    const frame_expr = new FrameExpr([frame_string, frame_string_2]);
+    const result = frame_expr.in(frame);
 
     expect(result.toString()).to.equal(`“${js_string}${js_string_2}”`);
   });
@@ -57,6 +58,7 @@ describe("FrameExpr", () => {
 
     const s_speed = new FrameSymbol("speed");
     const s_gap = new FrameSymbol("gap");
+    const expr_array = [s_speed, s_gap, FrameArg.here()];
 
     it("evaluates properties in its local context", () => {
       const frame_expr = new FrameExpr([s_speed], {speed: slow, gap: space});
@@ -65,8 +67,14 @@ describe("FrameExpr", () => {
     });
 
     it("evaluates a sequence of properties", () => {
-      const expr_array = [s_speed, s_gap, FrameArg.here()];
       const frame_expr = new FrameExpr(expr_array, {speed: slow, gap: space});
+
+      expect(frame_expr.call(turtle).toString()).to.equal(`“slow turtle”`);
+    });
+
+    it("evaluates recursively", () => {
+      const sub_expr = new FrameExpr(expr_array)
+      const frame_expr = new FrameExpr([sub_expr], {speed: slow, gap: space});
 
       expect(frame_expr.call(turtle).toString()).to.equal(`“slow turtle”`);
     });

--- a/test/frames/frame-expr-spec.ts
+++ b/test/frames/frame-expr-spec.ts
@@ -14,7 +14,7 @@ describe("FrameExpr", () => {
 
   it("replaces nil when evaluated", () => {
     const frame_expr = new FrameExpr([frame, frame_string], {context: context});
-    const result = frame_expr.in(frame);
+    const result = frame_expr.in([frame]);
     expect(result).to.equal(frame_string);
   });
 
@@ -22,7 +22,7 @@ describe("FrameExpr", () => {
     const js_string_2 = ", MAML!";
     const frame_string_2 = new FrameString(js_string_2);
     const frame_expr = new FrameExpr([frame_string, frame_string_2]);
-    const result = frame_expr.in(frame);
+    const result = frame_expr.in([frame]);
 
     expect(result.toString()).to.equal(`“${js_string}${js_string_2}”`);
   });
@@ -30,7 +30,7 @@ describe("FrameExpr", () => {
   it("returns context for FrameArg.here", () => {
     const context = new FrameString("context", {key: frame_string});
     const frame_expr = new FrameExpr([FrameArg.here()]);
-    const result = frame_expr.in(context);
+    const result = frame_expr.in([context]);
 
     expect(result).to.equal(context);
   });
@@ -38,7 +38,7 @@ describe("FrameExpr", () => {
   it("extracts properties from the context", () => {
     const context = new FrameString("context", {key: frame_string});
     const frame_expr = FrameExpr.extract("key");
-    const result = frame_expr.in(context);
+    const result = frame_expr.in([context]);
 
     expect(result).to.equal(frame_string);
   });

--- a/test/frames/frame-lazy-spec.ts
+++ b/test/frames/frame-lazy-spec.ts
@@ -20,7 +20,7 @@ describe("FrameLazy", () => {
   });
 
   it("evalutes to an Expr with merged context", () => {
-    const expr = lazy.in(context);
+    const expr = lazy.in([context]);
 
     expect(expr).to.be.instanceof(FrameExpr);
     expect(expr.toString()).to.equal(`(speed gap _, .speed “slow”; .gap “ ”;)`);
@@ -38,7 +38,7 @@ describe("FrameLazy", () => {
     });
 
     it("returns itself when Frame is nil", () => {
-      expect(codify.in(context)).to.equal(codify);
+      expect(codify.in([context])).to.equal(codify);
     });
 
     it("converts Array to Expr when called", () => {

--- a/test/frames/frame-name-spec.ts
+++ b/test/frames/frame-name-spec.ts
@@ -23,7 +23,7 @@ describe("FrameName", () => {
     const value = FrameSymbol.for("smasher");
     const context = new FrameString("context", {atom: value});
     const frame_expr = new FrameExpr([FrameArg.here(), frame_name]);
-    const result = frame_expr.in(context);
+    const result = frame_expr.in([context]);
 
     expect(result).to.equal(value);
   });

--- a/test/frames/frame-symbol-spec.ts
+++ b/test/frames/frame-symbol-spec.ts
@@ -28,7 +28,7 @@ describe("FrameSymbol", () => {
   it("looks itself up in context", () => {
     const value = FrameSymbol.for("smasher");
     const context = new FrameSymbol("parent", {atom: value});
-    const result = frame_symbol.in(context);
+    const result = frame_symbol.in([context]);
     expect(result).to.equal(value);
   });
 });

--- a/test/maml/maml-html-spec.ts
+++ b/test/maml/maml-html-spec.ts
@@ -15,7 +15,7 @@ const html_call = (content: FrameString) => {
     html_wrap("head", html_head),
     html_wrap("body", content),
   ]);
-  return html.in(Frame.nil);
+  return html.in([Frame.nil]);
 };
 
 describe("FrameHTML", () => {

--- a/test/maml/maml-spec.ts
+++ b/test/maml/maml-spec.ts
@@ -3,8 +3,8 @@ import { Frame, FrameExpr, FrameString } from "../../src/frames";
 import { maml } from "../../src/maml";
 
 describe("maml", () => {
-  const text = "Hello, MAML!";
-  const body = new FrameString(text);
+  const body_text = "Hello, MAML!";
+  const body = new FrameString(body_text);
   const result = maml.call(body);
   const result_string = result.toString();
 
@@ -17,8 +17,13 @@ describe("maml", () => {
     expect(tag).to.be.instanceOf(FrameExpr);
   });
 
+  it("wraps everything in an HTML tag", () => {
+    expect(result).to.be.instanceOf(FrameString);
+    expect(result_string).to.match(/<html>([\s\S]*)<\/html>/);
+  });
+
   it("wraps its argument in a body tag", () => {
     expect(result).to.be.instanceOf(FrameString);
-    expect(result_string).to.match(/<body>([\s\S]*)<\/body>/);
+    expect(result_string).to.equal(`“<body>${body_text}<\/body>”`);
   });
 });

--- a/test/maml/tag-spec.ts
+++ b/test/maml/tag-spec.ts
@@ -38,7 +38,7 @@ describe("MAML Tag", () => {
       new FrameString("body"),
     ]);
     const scope = new FrameString("scope", {tag});
-    const evaluated = expr.in(scope)
+    const evaluated = expr.in([scope])
     expect(evaluated.toString()).to.equal("(“<body>” _ “</body>”)");
   });
 
@@ -50,7 +50,7 @@ describe("MAML Tag", () => {
       new FrameString(contents),
     ]);
     const scope = new FrameString("scope", {tag});
-    const evaluated = expr.in(scope)
+    const evaluated = expr.in([scope])
     const evaluated_string = evaluated.toString();
 
     expect(evaluated).to.be.instanceOf(FrameString);


### PR DESCRIPTION
Have each evaluation context pass its scope through ‘in’, and have symbol iterate over them until it find a match.

Hopefully this will be cleaner than explicitly setting the ‘up’ value of each contained element.

NOTE: this is top-down; should we iterate bottom up? With ‘context’ first?